### PR TITLE
Clean up dead_code compiler warnings

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -28,7 +28,15 @@ impl RuleEngine {
         let mut findings: Vec<Finding> = self
             .rules
             .iter()
-            .flat_map(|rule| rule.check(source, tree, file_path))
+            .flat_map(|rule| {
+                let mut rule_findings = rule.check(source, tree, file_path);
+                for finding in &mut rule_findings {
+                    finding.rule_id = rule.id();
+                    finding.severity = rule.severity();
+                    finding.message = format!("{}: {}", rule.name(), finding.message);
+                }
+                rule_findings
+            })
             .collect();
         findings.sort_by(|a, b| a.line.cmp(&b.line).then(a.column.cmp(&b.column)));
         findings

--- a/src/parsers/javascript.rs
+++ b/src/parsers/javascript.rs
@@ -10,12 +10,6 @@ pub struct TsParser;
 pub struct TsxParser;
 
 impl LanguageParser for JsParser {
-    fn language_id(&self) -> &str {
-        "javascript"
-    }
-    fn file_extensions(&self) -> &[&str] {
-        &["js", "jsx"]
-    }
     fn parse(&self, source: &[u8]) -> Result<tree_sitter::Tree, String> {
         let mut parser = Parser::new();
         parser
@@ -28,12 +22,6 @@ impl LanguageParser for JsParser {
 }
 
 impl LanguageParser for TsParser {
-    fn language_id(&self) -> &str {
-        "typescript"
-    }
-    fn file_extensions(&self) -> &[&str] {
-        &["ts"]
-    }
     fn parse(&self, source: &[u8]) -> Result<tree_sitter::Tree, String> {
         let mut parser = Parser::new();
         parser
@@ -46,12 +34,6 @@ impl LanguageParser for TsParser {
 }
 
 impl LanguageParser for TsxParser {
-    fn language_id(&self) -> &str {
-        "tsx"
-    }
-    fn file_extensions(&self) -> &[&str] {
-        &["tsx"]
-    }
     fn parse(&self, source: &[u8]) -> Result<tree_sitter::Tree, String> {
         let mut parser = Parser::new();
         parser

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -5,7 +5,5 @@
 pub mod javascript;
 
 pub trait LanguageParser: Send + Sync {
-    fn language_id(&self) -> &str;
-    fn file_extensions(&self) -> &[&str];
     fn parse(&self, source: &[u8]) -> Result<tree_sitter::Tree, String>;
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -10,7 +10,6 @@ use std::path::Path;
 pub trait Rule: Send + Sync {
     fn id(&self) -> &'static str;
     fn name(&self) -> &'static str;
-    fn description(&self) -> &'static str;
     fn severity(&self) -> Severity;
     fn check(&self, source: &[u8], tree: &tree_sitter::Tree, file_path: &Path) -> Vec<Finding>;
 }

--- a/src/rules/slop/redundant_comment.rs
+++ b/src/rules/slop/redundant_comment.rs
@@ -28,9 +28,6 @@ impl Rule for RedundantComment {
     fn name(&self) -> &'static str {
         "Redundant Comment"
     }
-    fn description(&self) -> &'static str {
-        "Comment restates the adjacent code without adding meaningful context"
-    }
     fn severity(&self) -> Severity {
         Severity::Warn
     }
@@ -131,8 +128,8 @@ impl RedundantComment {
         if overlap >= OVERLAP_THRESHOLD {
             let start = node.start_position();
             Some(Finding {
-                rule_id: "slop-001",
-                message: "Redundant Comment: comment restates the adjacent code".to_string(),
+                rule_id: "",
+                message: "comment restates the adjacent code".to_string(),
                 severity: Severity::Warn,
                 file: file_path.to_path_buf(),
                 line: start.row + 1,

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -90,10 +90,6 @@ const STOP_WORDS: &[&str] = &[
     "the", "a", "an", "this", "that", "to", "of", "in", "for", "is", "it", "be", "as", "with",
 ];
 
-pub fn is_stop_word(word: &str) -> bool {
-    STOP_WORDS.contains(&word.to_lowercase().as_str())
-}
-
 /// Strip comment markers and extract meaningful tokens from comment text.
 /// Removes `//`, `/*`, `*/`, `*` line prefixes, stop words; stems and lowercases.
 pub fn extract_comment_tokens(comment_text: &str) -> Vec<String> {
@@ -178,13 +174,6 @@ mod tests {
     fn test_stem_short_words_unchanged() {
         assert_eq!(stem_word("is"), "is");
         assert_eq!(stem_word("as"), "as");
-    }
-
-    #[test]
-    fn test_is_stop_word() {
-        assert!(is_stop_word("the"));
-        assert!(is_stop_word("The"));
-        assert!(!is_stop_word("counter"));
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -19,6 +19,7 @@ pub struct Finding {
     pub suggestion: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Severity {
@@ -27,6 +28,7 @@ pub enum Severity {
     Info,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Category {


### PR DESCRIPTION
Closes #11

## Summary

- Wire `Rule` trait methods (`id`, `name`, `severity`) into `RuleEngine` so the engine enriches findings from trait metadata instead of rules hardcoding their own identity
- Remove unused `LanguageParser` trait methods (`language_id`, `file_extensions`) — `parser_for_extension()` and `SUPPORTED_EXTENSIONS` already handle mapping
- Remove dead `is_stop_word` function (logic inlined in `extract_comment_tokens`)
- Remove unused `description()` from `Rule` trait (no consumer, YAGNI)
- Add `#[allow(dead_code)]` to `Severity` and `Category` domain enums (idiomatic for enums with variants reserved for future rules)

## Test plan

- [x] `cargo build 2>&1 | grep warning` produces no output
- [x] `cargo test` — all 16 tests pass
- [x] `cargo clippy` — no new warnings (pre-existing `collapsible_if` suggestions unchanged)
- [x] No `#[allow(dead_code)]` on trait methods — traits were wired in or trimmed