### PR TITLE
Pass source bytes through pipeline to avoid TOCTOU race

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use clap::Parser;
 use cli::{Cli, Command, OutputFormat};
 use engine::RuleEngine;
 use reporters::Reporter;
+use std::collections::HashMap;
 use std::process;
 
 fn main() {
@@ -32,6 +33,7 @@ fn main() {
 
             // Analyze each file
             let mut all_findings = Vec::new();
+            let mut sources = HashMap::new();
             for file_path in &files {
                 let source = match std::fs::read(file_path) {
                     Ok(s) => s,
@@ -61,6 +63,7 @@ fn main() {
 
                 let findings = engine.analyze(&source, &tree, file_path);
                 all_findings.extend(findings);
+                sources.insert(file_path.clone(), source);
             }
 
             // Report findings
@@ -69,7 +72,7 @@ fn main() {
                 OutputFormat::Json => Box::new(reporters::json::JsonReporter),
             };
 
-            if let Err(e) = reporter.report(&all_findings) {
+            if let Err(e) = reporter.report(&all_findings, &sources) {
                 eprintln!("Error reporting findings: {e}");
                 process::exit(2);
             }

--- a/src/reporters/json.rs
+++ b/src/reporters/json.rs
@@ -4,11 +4,13 @@
 
 use crate::reporters::Reporter;
 use crate::types::Finding;
+use std::collections::HashMap;
+use std::path::PathBuf;
 
 pub struct JsonReporter;
 
 impl Reporter for JsonReporter {
-    fn report(&self, findings: &[Finding]) -> Result<(), Box<dyn std::error::Error>> {
+    fn report(&self, findings: &[Finding], _sources: &HashMap<PathBuf, Vec<u8>>) -> Result<(), Box<dyn std::error::Error>> {
         let json = serde_json::to_string_pretty(findings)?;
         println!("{json}");
         Ok(())

--- a/src/reporters/mod.rs
+++ b/src/reporters/mod.rs
@@ -6,7 +6,9 @@ pub mod json;
 pub mod terminal;
 
 use crate::types::Finding;
+use std::collections::HashMap;
+use std::path::PathBuf;
 
 pub trait Reporter {
-    fn report(&self, findings: &[Finding]) -> Result<(), Box<dyn std::error::Error>>;
+    fn report(&self, findings: &[Finding], sources: &HashMap<PathBuf, Vec<u8>>) -> Result<(), Box<dyn std::error::Error>>;
 }

--- a/src/reporters/terminal.rs
+++ b/src/reporters/terminal.rs
@@ -5,13 +5,13 @@
 use crate::reporters::Reporter;
 use crate::types::Finding;
 use ariadne::{Label, Report, ReportKind, Source};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 
 pub struct TerminalReporter;
 
 impl Reporter for TerminalReporter {
-    fn report(&self, findings: &[Finding]) -> Result<(), Box<dyn std::error::Error>> {
+    fn report(&self, findings: &[Finding], sources: &HashMap<PathBuf, Vec<u8>>) -> Result<(), Box<dyn std::error::Error>> {
         if findings.is_empty() {
             return Ok(());
         }
@@ -23,9 +23,11 @@ impl Reporter for TerminalReporter {
         }
 
         for (file_path, file_findings) in &by_file {
-            let source_text = std::fs::read_to_string(file_path)?;
+            let source_bytes = sources.get(file_path.as_path())
+                .ok_or_else(|| format!("Missing source for {}", file_path.display()))?;
+            let source_text = String::from_utf8_lossy(source_bytes);
             let file_id = file_path.display().to_string();
-            let source = Source::from(source_text.as_str());
+            let source = Source::from(source_text.as_ref());
 
             for finding in file_findings {
                 let kind = match finding.severity {


### PR DESCRIPTION
Closes #2

## Summary

- Collect source bytes into a `HashMap<PathBuf, Vec<u8>>` during the scan loop in `main.rs`
- Change `Reporter::report()` to accept the source map instead of re-reading files from disk
- Terminal reporter uses the in-memory source via `String::from_utf8_lossy`
- JSON reporter ignores the source map (doesn't need file contents)

## Test plan

- [x] `cargo build` — zero warnings
- [x] `cargo test` — all 16 tests pass
- [x] `cargo run -- scan tests/fixtures` — terminal output unchanged
- [x] `cargo run -- scan tests/fixtures --format json` — JSON output unchanged