### PR TITLE
Handle inline/trailing comments in slop-001

### DIFF
--- a/tests/fixtures/slop/redundant_comments.js
+++ b/tests/fixtures/slop/redundant_comments.js
@@ -46,3 +46,9 @@ initializeApplicationConfig();
 // expect: slop-001
 // Update the user profile data
 updateUserProfileData(data);
+
+// expect: slop-001
+const config = getApplicationConfig(); // Get the application config
+
+// This should NOT trigger — trailing comment adds context beyond code
+const timeout = 30000; // Maximum wait time before circuit breaker trips

--- a/tests/integration/scan_test.rs
+++ b/tests/integration/scan_test.rs
@@ -22,7 +22,7 @@ fn slop_001_detects_redundant_comments() {
     let findings: Vec<serde_json::Value> = serde_json::from_str(&stdout)
         .expect("output should be valid JSON");
 
-    assert_eq!(findings.len(), 5, "expected 5 findings, got {}", findings.len());
+    assert_eq!(findings.len(), 6, "expected 6 findings, got {}", findings.len());
 
     // All findings should be slop-001
     for finding in &findings {
@@ -32,7 +32,7 @@ fn slop_001_detects_redundant_comments() {
 
     // Verify specific line numbers
     let lines: Vec<u64> = findings.iter().map(|f| f["line"].as_u64().unwrap()).collect();
-    assert_eq!(lines, vec![6, 10, 14, 43, 47]);
+    assert_eq!(lines, vec![6, 10, 14, 43, 47, 51]);
 }
 
 #[test]


### PR DESCRIPTION
Closes #4

## Summary

- Check `prev_named_sibling()` first for inline/trailing comments (same line as code)
- Fall back to `next_named_sibling()` for standard above-code comments
- Add trailing comment test fixture and negative case for contextful trailing comments

## Test plan

- [x] `cargo build` — zero warnings
- [x] `cargo test` — all 16 tests pass
- [x] New fixture: `const config = getApplicationConfig(); // Get the application config` detected
- [x] Negative case: `const timeout = 30000; // Maximum wait time before circuit breaker trips` not flagged