### PR TITLE
Log warnings for silently skipped files

### DIFF
--- a/src/rules/slop/redundant_comment.rs
+++ b/src/rules/slop/redundant_comment.rs
@@ -41,7 +41,10 @@ impl Rule for RedundantComment {
         let mut findings = Vec::new();
         let source_str = match std::str::from_utf8(source) {
             Ok(s) => s,
-            Err(_) => return findings,
+            Err(_) => {
+                eprintln!("Warning: {} is not valid UTF-8, skipping", file_path.display());
+                return findings;
+            }
         };
 
         let mut cursor = tree.walk();

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -20,7 +20,10 @@ pub fn scan_files(path: &Path) -> Vec<PathBuf> {
     for entry in WalkBuilder::new(path).build() {
         let entry = match entry {
             Ok(e) => e,
-            Err(_) => continue,
+            Err(e) => {
+                eprintln!("Warning: {e}");
+                continue;
+            }
         };
         let path = entry.path();
         if path.is_file() && has_supported_extension(path) {


### PR DESCRIPTION
Closes #3

## Summary

- Log warning to stderr when a file is skipped due to non-UTF-8 content
- Log warning to stderr for directory walk errors (permission denied, symlink loops, etc.)

## Test plan

- [x] `cargo build` — zero warnings
- [x] `cargo test` — all 16 tests pass