### PR TITLE
Cache parsers instead of recreating per file

### DIFF
--- a/src/parsers/javascript.rs
+++ b/src/parsers/javascript.rs
@@ -3,19 +3,55 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use super::LanguageParser;
+use std::cell::RefCell;
 use tree_sitter::{Language, Parser};
 
-pub struct JsParser;
-pub struct TsParser;
-pub struct TsxParser;
+pub struct JsParser {
+    parser: RefCell<Parser>,
+}
 
-impl LanguageParser for JsParser {
-    fn parse(&self, source: &[u8]) -> Result<tree_sitter::Tree, String> {
+pub struct TsParser {
+    parser: RefCell<Parser>,
+}
+
+pub struct TsxParser {
+    parser: RefCell<Parser>,
+}
+
+impl JsParser {
+    pub fn new() -> Result<Self, String> {
         let mut parser = Parser::new();
         parser
             .set_language(&Language::from(tree_sitter_javascript::LANGUAGE))
             .map_err(|e| format!("Failed to set JS language: {e}"))?;
+        Ok(Self { parser: RefCell::new(parser) })
+    }
+}
+
+impl TsParser {
+    pub fn new() -> Result<Self, String> {
+        let mut parser = Parser::new();
         parser
+            .set_language(&Language::from(tree_sitter_typescript::LANGUAGE_TYPESCRIPT))
+            .map_err(|e| format!("Failed to set TS language: {e}"))?;
+        Ok(Self { parser: RefCell::new(parser) })
+    }
+}
+
+impl TsxParser {
+    pub fn new() -> Result<Self, String> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&Language::from(tree_sitter_typescript::LANGUAGE_TSX))
+            .map_err(|e| format!("Failed to set TSX language: {e}"))?;
+        Ok(Self { parser: RefCell::new(parser) })
+    }
+}
+
+impl LanguageParser for JsParser {
+    fn parse(&self, source: &[u8]) -> Result<tree_sitter::Tree, String> {
+        self.parser
+            .borrow_mut()
             .parse(source, None)
             .ok_or_else(|| "Failed to parse JavaScript source".to_string())
     }
@@ -23,11 +59,8 @@ impl LanguageParser for JsParser {
 
 impl LanguageParser for TsParser {
     fn parse(&self, source: &[u8]) -> Result<tree_sitter::Tree, String> {
-        let mut parser = Parser::new();
-        parser
-            .set_language(&Language::from(tree_sitter_typescript::LANGUAGE_TYPESCRIPT))
-            .map_err(|e| format!("Failed to set TS language: {e}"))?;
-        parser
+        self.parser
+            .borrow_mut()
             .parse(source, None)
             .ok_or_else(|| "Failed to parse TypeScript source".to_string())
     }
@@ -35,21 +68,18 @@ impl LanguageParser for TsParser {
 
 impl LanguageParser for TsxParser {
     fn parse(&self, source: &[u8]) -> Result<tree_sitter::Tree, String> {
-        let mut parser = Parser::new();
-        parser
-            .set_language(&Language::from(tree_sitter_typescript::LANGUAGE_TSX))
-            .map_err(|e| format!("Failed to set TSX language: {e}"))?;
-        parser
+        self.parser
+            .borrow_mut()
             .parse(source, None)
             .ok_or_else(|| "Failed to parse TSX source".to_string())
     }
 }
 
-pub fn parser_for_extension(ext: &str) -> Option<Box<dyn LanguageParser>> {
+pub fn parser_for_extension(ext: &str) -> Option<Result<Box<dyn LanguageParser>, String>> {
     match ext {
-        "js" | "jsx" => Some(Box::new(JsParser)),
-        "ts" => Some(Box::new(TsParser)),
-        "tsx" => Some(Box::new(TsxParser)),
+        "js" | "jsx" => Some(JsParser::new().map(|p| Box::new(p) as Box<dyn LanguageParser>)),
+        "ts" => Some(TsParser::new().map(|p| Box::new(p) as Box<dyn LanguageParser>)),
+        "tsx" => Some(TsxParser::new().map(|p| Box::new(p) as Box<dyn LanguageParser>)),
         _ => None,
     }
 }

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -4,6 +4,6 @@
 
 pub mod javascript;
 
-pub trait LanguageParser: Send + Sync {
+pub trait LanguageParser {
     fn parse(&self, source: &[u8]) -> Result<tree_sitter::Tree, String>;
 }


### PR DESCRIPTION
Closes #7

## Summary

- Parser impls now hold a `RefCell<Parser>` with the language pre-configured at construction
- Parsers cached by extension in a `HashMap` in `main.rs` — created once, reused across files
- Removed unused `Send + Sync` bounds from `LanguageParser` trait (project is single-threaded)

## Test plan

- [x] `cargo build` — zero warnings
- [x] `cargo test` — all 16 tests pass