### PR TITLE
Replace custom stemmer with Snowball/Porter2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
  "ariadne",
  "clap",
  "ignore",
+ "rust-stemmers",
  "serde",
  "serde_json",
  "tree-sitter",
@@ -315,6 +316,16 @@ name = "regex-syntax"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
 
 [[package]]
 name = "same-file"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "GPL-3.0-only"
 ariadne = "0.6.0"
 clap = { version = "4.5.58", features = ["derive"] }
 ignore = "0.4.25"
+rust-stemmers = "1.2.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tree-sitter = "0.26.5"


### PR DESCRIPTION
Closes #5

## Summary

- Replace hand-rolled suffix stripper with `rust-stemmers` crate (Snowball/Porter2 algorithm)
- Fixes inconsistent stems: `setting`/`set` and `initializing`/`initialize` now normalize consistently
- Removes ~40 lines of custom stemming logic

## Test plan

- [x] `cargo build` — zero warnings
- [x] `cargo test` — all 16 tests pass
- [x] `cargo tree -d` — no duplicate dependencies
- [x] Integration tests confirm same findings on existing fixtures