### PR TITLE
Clippy and idiomatic Rust cleanup

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -6,13 +6,14 @@ use crate::rules::Rule;
 use crate::types::Finding;
 use std::path::Path;
 
+#[derive(Default)]
 pub struct RuleEngine {
     rules: Vec<Box<dyn Rule>>,
 }
 
 impl RuleEngine {
     pub fn new() -> Self {
-        Self { rules: Vec::new() }
+        Self::default()
     }
 
     pub fn register(&mut self, rule: Box<dyn Rule>) {

--- a/src/rules/slop/redundant_comment.rs
+++ b/src/rules/slop/redundant_comment.rs
@@ -63,11 +63,10 @@ impl RedundantComment {
         loop {
             let node = cursor.node();
 
-            if node.kind() == "comment" {
-                if let Some(finding) = Self::check_comment(node, source, file_path) {
+            if node.kind() == "comment"
+                && let Some(finding) = Self::check_comment(node, source, file_path) {
                     findings.push(finding);
                 }
-            }
 
             if cursor.goto_first_child() {
                 continue;
@@ -184,11 +183,10 @@ impl RedundantComment {
         let mut cursor = node.walk();
         loop {
             let kind = cursor.node().kind();
-            if kind == "identifier" || kind == "property_identifier" || kind == "shorthand_property_identifier" || kind == "shorthand_property_identifier_pattern" {
-                if let Ok(text) = cursor.node().utf8_text(source.as_bytes()) {
+            if (kind == "identifier" || kind == "property_identifier" || kind == "shorthand_property_identifier" || kind == "shorthand_property_identifier_pattern")
+                && let Ok(text) = cursor.node().utf8_text(source.as_bytes()) {
                     identifiers.push(text.to_string());
                 }
-            }
 
             if cursor.goto_first_child() {
                 continue;

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use rust_stemmers::{Algorithm, Stemmer};
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 /// Splits a CamelCase or snake_case identifier into lowercase component words.
 ///
@@ -63,8 +63,6 @@ pub fn extract_comment_tokens(comment_text: &str) -> Vec<String> {
         .unwrap_or(comment_text.trim());
     let cleaned = cleaned.strip_suffix("*/").unwrap_or(cleaned);
 
-    let stop: HashSet<&str> = STOP_WORDS.iter().copied().collect();
-
     cleaned
         .lines()
         .flat_map(|line| {
@@ -74,7 +72,7 @@ pub fn extract_comment_tokens(comment_text: &str) -> Vec<String> {
         .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()))
         .filter(|w| !w.is_empty() && w.len() > 1)
         .map(|w| w.to_lowercase())
-        .filter(|w| !stop.contains(w.as_str()))
+        .filter(|w| !STOP_WORDS.contains(&w.as_str()))
         .map(|w| stem_word(&w))
         .collect()
 }
@@ -82,7 +80,7 @@ pub fn extract_comment_tokens(comment_text: &str) -> Vec<String> {
 /// Extract tokens from code identifiers.
 /// Splits each identifier by CamelCase/snake_case, stems, and lowercases.
 pub fn extract_code_tokens(identifiers: &[&str]) -> Vec<String> {
-    let mut tokens: HashSet<String> = HashSet::new();
+    let mut tokens: BTreeSet<String> = BTreeSet::new();
     for ident in identifiers {
         for word in split_identifier(ident) {
             tokens.insert(stem_word(&word));


### PR DESCRIPTION
Closes #8

## Summary

- Fix collapsible `if` blocks in `redundant_comment.rs` (clippy auto-fix)
- Derive `Default` for `RuleEngine` instead of manual impl
- Replace per-call `HashSet` allocation with direct `STOP_WORDS.contains()` (linear scan is faster for 14 items)
- Use `BTreeSet` in `extract_code_tokens` for deterministic iteration order

## Test plan

- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — all 16 tests pass