### PR TITLE
Add slop-002: detect AI reasoning artifacts in comments

### DIFF
--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -15,5 +15,8 @@ pub trait Rule: Send + Sync {
 }
 
 pub fn all_rules() -> Vec<Box<dyn Rule>> {
-    vec![Box::new(slop::redundant_comment::RedundantComment)]
+    vec![
+        Box::new(slop::redundant_comment::RedundantComment),
+        Box::new(slop::reasoning_artifact::ReasoningArtifact),
+    ]
 }

--- a/src/rules/slop/mod.rs
+++ b/src/rules/slop/mod.rs
@@ -2,4 +2,5 @@
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
+pub mod reasoning_artifact;
 pub mod redundant_comment;

--- a/src/rules/slop/reasoning_artifact.rs
+++ b/src/rules/slop/reasoning_artifact.rs
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2026 Steven Mosley <astrosteveo>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::rules::Rule;
+use crate::types::{Finding, Severity};
+use std::path::Path;
+
+/// Multi-word patterns that indicate AI reasoning traces in comments.
+/// Each pattern is matched case-insensitively at the start of a line within the comment.
+const REASONING_PATTERNS: &[&str] = &[
+    "wait —",
+    "wait -",
+    "wait,",
+    "actually,",
+    "actually —",
+    "actually -",
+    "hmm,",
+    "hmm.",
+    "let me think",
+    "let me reconsider",
+    "let's be precise",
+    "let's try",
+    "on second thought",
+    "i think we should",
+    "i believe this",
+    "i'm not sure",
+    "that doesn't work",
+    "let me re-read",
+    "let me re-examine",
+];
+
+pub struct ReasoningArtifact;
+
+impl Rule for ReasoningArtifact {
+    fn id(&self) -> &'static str {
+        "slop-002"
+    }
+    fn name(&self) -> &'static str {
+        "Reasoning Artifact"
+    }
+    fn severity(&self) -> Severity {
+        Severity::Warn
+    }
+
+    fn check(
+        &self,
+        source: &[u8],
+        tree: &tree_sitter::Tree,
+        file_path: &Path,
+    ) -> Vec<Finding> {
+        let mut findings = Vec::new();
+        let source_str = match std::str::from_utf8(source) {
+            Ok(s) => s,
+            Err(_) => return findings,
+        };
+
+        let mut cursor = tree.walk();
+        Self::walk_tree(&mut cursor, source_str, file_path, &mut findings);
+        findings
+    }
+}
+
+impl ReasoningArtifact {
+    fn walk_tree(
+        cursor: &mut tree_sitter::TreeCursor,
+        source: &str,
+        file_path: &Path,
+        findings: &mut Vec<Finding>,
+    ) {
+        loop {
+            let node = cursor.node();
+
+            if node.kind() == "comment"
+                && let Some(finding) = Self::check_comment(node, source, file_path) {
+                    findings.push(finding);
+                }
+
+            if cursor.goto_first_child() {
+                continue;
+            }
+            if cursor.goto_next_sibling() {
+                continue;
+            }
+            loop {
+                if !cursor.goto_parent() {
+                    return;
+                }
+                if cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+    }
+
+    fn check_comment(
+        node: tree_sitter::Node,
+        source: &str,
+        file_path: &Path,
+    ) -> Option<Finding> {
+        let text = node.utf8_text(source.as_bytes()).ok()?;
+
+        // Strip comment markers and check each line
+        let cleaned = text
+            .trim()
+            .strip_prefix("//")
+            .or_else(|| text.trim().strip_prefix("/*"))
+            .unwrap_or(text.trim());
+        let cleaned = cleaned.strip_suffix("*/").unwrap_or(cleaned);
+
+        for line in cleaned.lines() {
+            let line = line.trim().strip_prefix('*').unwrap_or(line.trim()).trim();
+            let lower = line.to_lowercase();
+
+            for pattern in REASONING_PATTERNS {
+                if lower.starts_with(pattern) {
+                    let start = node.start_position();
+                    return Some(Finding {
+                        rule_id: "",
+                        message: "comment contains AI reasoning trace".to_string(),
+                        severity: Severity::Warn,
+                        file: file_path.to_path_buf(),
+                        line: start.row + 1,
+                        column: start.column + 1,
+                        span: node.byte_range(),
+                        suggestion: Some(
+                            "Remove this comment — it appears to be an AI chain-of-thought artifact."
+                                .to_string(),
+                        ),
+                    });
+                }
+            }
+        }
+
+        None
+    }
+}

--- a/tests/fixtures/slop/reasoning_artifacts.js
+++ b/tests/fixtures/slop/reasoning_artifacts.js
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Steven Mosley <astrosteveo>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+// expect: slop-002
+// Wait — this might not handle edge cases correctly
+function processData(data) {
+    return data.filter(Boolean);
+}
+
+// expect: slop-002
+// Actually, let me reconsider the approach here
+function validateInput(input) {
+    return input != null;
+}
+
+// expect: slop-002
+// Hmm, I think we should use a different data structure
+const cache = new Map();
+
+// expect: slop-002
+// Let me think about the performance implications
+function sortItems(items) {
+    return items.sort((a, b) => a - b);
+}
+
+// expect: slop-002
+// On second thought, this is the better approach
+function formatDate(date) {
+    return date.toISOString();
+}
+
+// This should NOT trigger — legitimate use of "wait" in context
+// Users must wait for the async operation to complete
+async function fetchData(url) {
+    return await fetch(url);
+}
+
+// This should NOT trigger — "actually" mid-sentence, not reasoning
+// The server actually returns a 204 for empty responses
+function handleResponse(res) {
+    return res.status;
+}
+
+// This should NOT trigger — normal TODO comment
+// TODO: think about caching strategy
+function getUser(id) {
+    return db.find(id);
+}


### PR DESCRIPTION
Closes #10

## Summary

- New rule `slop-002` (Reasoning Artifact) detects AI chain-of-thought traces left in comments
- Matches multi-word patterns case-insensitively at line start (e.g., "Wait —", "Actually,", "Let me think", "On second thought")
- Includes test fixture with 5 positive cases and 3 negative cases (legitimate "wait", mid-sentence "actually", TODO)
- Generalized `expect_annotations_match_findings` test to work across all fixture files

## Test plan

- [x] `cargo build` — zero warnings
- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — all 17 tests pass (9 unit + 8 integration)
- [x] Verified: 5 true positives, 0 false positives on fixture