### PR TITLE
v0.2: Rule expansion — slop-003 through slop-005, rules subcommand, severity threshold

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,17 @@ pub enum Command {
         /// Output format
         #[arg(long, default_value = "terminal")]
         format: OutputFormat,
+
+        /// Minimum severity to report (error, warn, info)
+        #[arg(long, default_value = "info")]
+        severity_threshold: SeverityThreshold,
+    },
+
+    /// List all available rules
+    Rules {
+        /// Output format
+        #[arg(long, default_value = "terminal")]
+        format: OutputFormat,
     },
 }
 
@@ -29,4 +40,11 @@ pub enum Command {
 pub enum OutputFormat {
     Terminal,
     Json,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+pub enum SeverityThreshold {
+    Error,
+    Warn,
+    Info,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,17 +12,22 @@ mod tokens;
 mod types;
 
 use clap::Parser;
-use cli::{Cli, Command, OutputFormat};
+use cli::{Cli, Command, OutputFormat, SeverityThreshold};
 use engine::RuleEngine;
 use reporters::Reporter;
 use std::collections::HashMap;
 use std::process;
+use types::Severity;
 
 fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Scan { ref path, ref format } => {
+        Command::Scan {
+            ref path,
+            ref format,
+            severity_threshold,
+        } => {
             let files = scanner::scan_files(path);
 
             // Build rule engine
@@ -34,7 +39,8 @@ fn main() {
             // Analyze each file
             let mut all_findings = Vec::new();
             let mut sources = HashMap::new();
-            let mut parser_cache: HashMap<String, Box<dyn parsers::LanguageParser>> = HashMap::new();
+            let mut parser_cache: HashMap<String, Box<dyn parsers::LanguageParser>> =
+                HashMap::new();
             for file_path in &files {
                 let source = match std::fs::read(file_path) {
                     Ok(s) => s,
@@ -51,7 +57,9 @@ fn main() {
 
                 if !parser_cache.contains_key(ext) {
                     match parsers::javascript::parser_for_extension(ext) {
-                        Some(Ok(p)) => { parser_cache.insert(ext.to_string(), p); }
+                        Some(Ok(p)) => {
+                            parser_cache.insert(ext.to_string(), p);
+                        }
                         Some(Err(e)) => {
                             eprintln!("Error initializing parser for .{ext}: {e}");
                             continue;
@@ -74,6 +82,9 @@ fn main() {
                 sources.insert(file_path.clone(), source);
             }
 
+            // Filter by severity threshold
+            all_findings.retain(|f| severity_passes(f.severity, severity_threshold));
+
             // Report findings
             let reporter: Box<dyn Reporter> = match format {
                 OutputFormat::Terminal => Box::new(reporters::terminal::TerminalReporter),
@@ -91,5 +102,57 @@ fn main() {
                 process::exit(1);
             }
         }
+
+        Command::Rules { ref format } => {
+            let all = rules::all_rules();
+            match format {
+                OutputFormat::Terminal => {
+                    println!("{:<12} {:<24} {:<10} Description", "ID", "Name", "Severity");
+                    println!("{}", "-".repeat(80));
+                    for rule in &all {
+                        println!(
+                            "{:<12} {:<24} {:<10} {}",
+                            rule.id(),
+                            rule.name(),
+                            rule.severity(),
+                            rule.description()
+                        );
+                    }
+                }
+                OutputFormat::Json => {
+                    let entries: Vec<serde_json::Value> = all
+                        .iter()
+                        .map(|rule| {
+                            serde_json::json!({
+                                "id": rule.id(),
+                                "name": rule.name(),
+                                "severity": format!("{}", rule.severity()),
+                                "description": rule.description(),
+                            })
+                        })
+                        .collect();
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&entries).expect("JSON serialization failed")
+                    );
+                }
+            }
+        }
     }
+}
+
+/// Returns true if the finding's severity meets or exceeds the threshold.
+/// Ordering: error > warn > info
+fn severity_passes(severity: Severity, threshold: SeverityThreshold) -> bool {
+    let level = |s: &Severity| match s {
+        Severity::Error => 2,
+        Severity::Warn => 1,
+        Severity::Info => 0,
+    };
+    level(&severity)
+        >= match threshold {
+            SeverityThreshold::Error => 2,
+            SeverityThreshold::Warn => 1,
+            SeverityThreshold::Info => 0,
+        }
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 pub trait Rule: Send + Sync {
     fn id(&self) -> &'static str;
     fn name(&self) -> &'static str;
+    fn description(&self) -> &'static str;
     fn severity(&self) -> Severity;
     fn check(&self, source: &[u8], tree: &tree_sitter::Tree, file_path: &Path) -> Vec<Finding>;
 }
@@ -18,5 +19,8 @@ pub fn all_rules() -> Vec<Box<dyn Rule>> {
     vec![
         Box::new(slop::redundant_comment::RedundantComment),
         Box::new(slop::reasoning_artifact::ReasoningArtifact),
+        Box::new(slop::filler_hedge::FillerHedge),
+        Box::new(slop::commented_out_code::CommentedOutCode),
+        Box::new(slop::self_narrating::SelfNarrating),
     ]
 }

--- a/src/rules/slop/commented_out_code.rs
+++ b/src/rules/slop/commented_out_code.rs
@@ -1,0 +1,373 @@
+// SPDX-FileCopyrightText: 2026 Steven Mosley <astrosteveo>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::rules::Rule;
+use crate::types::{Finding, Severity};
+use std::path::Path;
+
+/// JS/TS keywords that suggest a line is code rather than prose.
+const CODE_KEYWORDS: &[&str] = &[
+    "function", "const", "let", "var", "if", "else", "for", "while", "return", "import", "export",
+    "class", "switch", "case", "break", "continue", "throw", "try", "catch", "finally", "new",
+    "async", "await",
+];
+
+/// Minimum fraction of lines that must look like code to flag a multi-line comment group.
+const CODE_LINE_THRESHOLD: f64 = 0.6;
+
+pub struct CommentedOutCode;
+
+impl Rule for CommentedOutCode {
+    fn id(&self) -> &'static str {
+        "slop-004"
+    }
+    fn name(&self) -> &'static str {
+        "Commented-Out Code"
+    }
+    fn description(&self) -> &'static str {
+        "Detects blocks of commented-out code that should be removed"
+    }
+    fn severity(&self) -> Severity {
+        Severity::Warn
+    }
+
+    fn check(
+        &self,
+        source: &[u8],
+        tree: &tree_sitter::Tree,
+        file_path: &Path,
+    ) -> Vec<Finding> {
+        let mut findings = Vec::new();
+        let source_str = match std::str::from_utf8(source) {
+            Ok(s) => s,
+            Err(_) => return findings,
+        };
+
+        let mut cursor = tree.walk();
+        let mut comment_nodes = Vec::new();
+        Self::collect_comments(&mut cursor, &mut comment_nodes);
+
+        // Process groups of consecutive single-line comments
+        let mut i = 0;
+        while i < comment_nodes.len() {
+            let node = comment_nodes[i];
+            let text = match node.utf8_text(source_str.as_bytes()) {
+                Ok(t) => t,
+                Err(_) => {
+                    i += 1;
+                    continue;
+                }
+            };
+
+            // Handle block comments (/* ... */)
+            if text.starts_with("/*") {
+                if !Self::is_exempt_block(text)
+                    && let Some(finding) = Self::check_block_comment(node, text, file_path)
+                {
+                    findings.push(finding);
+                }
+                i += 1;
+                continue;
+            }
+
+            // Skip exempt single-line comments (annotations, SPDX headers)
+            let start_content = Self::strip_line_comment(text);
+            if Self::is_exempt_line(start_content) {
+                i += 1;
+                continue;
+            }
+
+            // Gather consecutive single-line // comments, breaking on exempt lines
+            let group_start = i;
+            let mut group_end = i + 1;
+            while group_end < comment_nodes.len() {
+                let prev = comment_nodes[group_end - 1];
+                let curr = comment_nodes[group_end];
+
+                let prev_text = match prev.utf8_text(source_str.as_bytes()) {
+                    Ok(t) => t,
+                    Err(_) => break,
+                };
+                let curr_text = match curr.utf8_text(source_str.as_bytes()) {
+                    Ok(t) => t,
+                    Err(_) => break,
+                };
+
+                // Both must be // comments on consecutive lines
+                if !prev_text.starts_with("//") || !curr_text.starts_with("//") {
+                    break;
+                }
+                if curr.start_position().row != prev.start_position().row + 1 {
+                    break;
+                }
+                // Don't include exempt lines (annotations, SPDX) in groups
+                let curr_content = Self::strip_line_comment(curr_text);
+                if Self::is_exempt_line(curr_content) {
+                    break;
+                }
+                group_end += 1;
+            }
+
+            let group = &comment_nodes[group_start..group_end];
+            if group.len() == 1 {
+                // Single-line comment: check if it's a complete statement
+                if let Some(finding) =
+                    Self::check_single_line(group[0], source_str, file_path)
+                {
+                    findings.push(finding);
+                }
+            } else {
+                // Multi-line group: check if ≥60% of lines look like code
+                if let Some(finding) =
+                    Self::check_comment_group(group, source_str, file_path)
+                {
+                    findings.push(finding);
+                }
+            }
+
+            i = group_end;
+        }
+
+        findings
+    }
+}
+
+impl CommentedOutCode {
+    fn collect_comments<'a>(
+        cursor: &mut tree_sitter::TreeCursor<'a>,
+        comments: &mut Vec<tree_sitter::Node<'a>>,
+    ) {
+        loop {
+            let node = cursor.node();
+            if node.kind() == "comment" {
+                comments.push(node);
+            }
+
+            if cursor.goto_first_child() {
+                continue;
+            }
+            if cursor.goto_next_sibling() {
+                continue;
+            }
+            loop {
+                if !cursor.goto_parent() {
+                    return;
+                }
+                if cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+    }
+
+    fn strip_line_comment(text: &str) -> &str {
+        text.strip_prefix("//").unwrap_or(text).trim()
+    }
+
+    fn is_exempt_block(text: &str) -> bool {
+        // JSDoc blocks
+        if text.starts_with("/**") {
+            return true;
+        }
+        // SPDX headers
+        let lower = text.to_lowercase();
+        if lower.contains("spdx-") {
+            return true;
+        }
+        false
+    }
+
+    fn is_exempt_line(line: &str) -> bool {
+        let trimmed = line.trim();
+        // @-annotations (JSDoc, decorators)
+        if trimmed.starts_with('@') {
+            return true;
+        }
+        // expect: annotations for testing
+        if trimmed.starts_with("expect:") {
+            return true;
+        }
+        // SPDX headers
+        let lower = trimmed.to_lowercase();
+        if lower.starts_with("spdx-") {
+            return true;
+        }
+        false
+    }
+
+    fn looks_like_code(line: &str) -> bool {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            return false;
+        }
+
+        // Exempt lines
+        if Self::is_exempt_line(trimmed) {
+            return false;
+        }
+
+        // Lines ending with code terminators
+        if trimmed.ends_with(';')
+            || trimmed.ends_with('{')
+            || trimmed.ends_with('}')
+            || trimmed.ends_with(')')
+        {
+            return true;
+        }
+
+        // Lines starting with JS keywords
+        let lower = trimmed.to_lowercase();
+        for kw in CODE_KEYWORDS {
+            if lower.starts_with(kw)
+                && trimmed
+                    .get(kw.len()..kw.len() + 1)
+                    .is_some_and(|c| c == " " || c == "(" || c == "{")
+            {
+                return true;
+            }
+        }
+
+        // Assignment operators
+        if trimmed.contains(" = ")
+            || trimmed.contains(" += ")
+            || trimmed.contains(" => ")
+            || trimmed.contains(" -= ")
+        {
+            return true;
+        }
+
+        // Method calls: foo.bar( or foo(
+        if trimmed.contains(".(") || (trimmed.contains('(') && trimmed.contains('.')) {
+            return true;
+        }
+
+        false
+    }
+
+    fn check_block_comment(
+        node: tree_sitter::Node,
+        text: &str,
+        file_path: &Path,
+    ) -> Option<Finding> {
+        let inner = text
+            .strip_prefix("/*")?
+            .strip_suffix("*/")?
+            .trim();
+
+        let lines: Vec<&str> = inner
+            .lines()
+            .map(|l| l.trim().strip_prefix('*').unwrap_or(l.trim()).trim())
+            .filter(|l| !l.is_empty())
+            .collect();
+
+        if lines.len() < 2 {
+            return None;
+        }
+
+        let code_lines = lines.iter().filter(|l| Self::looks_like_code(l)).count();
+        let ratio = code_lines as f64 / lines.len() as f64;
+
+        if ratio >= CODE_LINE_THRESHOLD {
+            let start = node.start_position();
+            Some(Finding {
+                rule_id: "",
+                message: "block comment contains commented-out code".to_string(),
+                severity: Severity::Warn,
+                file: file_path.to_path_buf(),
+                line: start.row + 1,
+                column: start.column + 1,
+                span: node.byte_range(),
+                suggestion: Some(
+                    "Remove commented-out code — use version control to preserve old code."
+                        .to_string(),
+                ),
+            })
+        } else {
+            None
+        }
+    }
+
+    fn check_single_line(
+        node: tree_sitter::Node,
+        source: &str,
+        file_path: &Path,
+    ) -> Option<Finding> {
+        let text = node.utf8_text(source.as_bytes()).ok()?;
+        let content = Self::strip_line_comment(text);
+
+        if content.is_empty() || Self::is_exempt_line(content) {
+            return None;
+        }
+
+        // Only flag if it looks like a complete statement
+        let is_statement = content.ends_with(';')
+            && (content.contains('(')
+                || content.contains('=')
+                || CODE_KEYWORDS
+                    .iter()
+                    .any(|kw| content.to_lowercase().starts_with(kw)));
+
+        if is_statement {
+            let start = node.start_position();
+            Some(Finding {
+                rule_id: "",
+                message: "comment contains commented-out code".to_string(),
+                severity: Severity::Warn,
+                file: file_path.to_path_buf(),
+                line: start.row + 1,
+                column: start.column + 1,
+                span: node.byte_range(),
+                suggestion: Some(
+                    "Remove commented-out code — use version control to preserve old code."
+                        .to_string(),
+                ),
+            })
+        } else {
+            None
+        }
+    }
+
+    fn check_comment_group(
+        group: &[tree_sitter::Node],
+        source: &str,
+        file_path: &Path,
+    ) -> Option<Finding> {
+        let lines: Vec<&str> = group
+            .iter()
+            .filter_map(|n| {
+                let text = n.utf8_text(source.as_bytes()).ok()?;
+                Some(Self::strip_line_comment(text))
+            })
+            .collect();
+
+        let non_empty: Vec<&&str> = lines.iter().filter(|l| !l.is_empty()).collect();
+        if non_empty.len() < 2 {
+            return None;
+        }
+
+        let code_lines = non_empty.iter().filter(|l| Self::looks_like_code(l)).count();
+        let ratio = code_lines as f64 / non_empty.len() as f64;
+
+        if ratio >= CODE_LINE_THRESHOLD {
+            let first = group[0];
+            let last = group[group.len() - 1];
+            let start = first.start_position();
+            Some(Finding {
+                rule_id: "",
+                message: "comment group contains commented-out code".to_string(),
+                severity: Severity::Warn,
+                file: file_path.to_path_buf(),
+                line: start.row + 1,
+                column: start.column + 1,
+                span: first.start_byte()..last.end_byte(),
+                suggestion: Some(
+                    "Remove commented-out code — use version control to preserve old code."
+                        .to_string(),
+                ),
+            })
+        } else {
+            None
+        }
+    }
+}

--- a/src/rules/slop/filler_hedge.rs
+++ b/src/rules/slop/filler_hedge.rs
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: 2026 Steven Mosley <astrosteveo>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::rules::Rule;
+use crate::types::{Finding, Severity};
+use std::path::Path;
+
+/// Phrase-start patterns that indicate filler/hedge language in comments.
+/// Matched case-insensitively at the start of a comment line.
+const PHRASE_START_PATTERNS: &[&str] = &[
+    "basically,",
+    "simply put",
+    "just ",
+    "obviously,",
+    "note:",
+    "important:",
+    "essentially,",
+    "please note",
+    "it's worth noting",
+    "it should be noted",
+    "worth mentioning",
+    "keep in mind",
+];
+
+/// Individual filler words counted for density heuristic.
+const FILLER_WORDS: &[&str] = &[
+    "basically",
+    "simply",
+    "just",
+    "obviously",
+    "essentially",
+    "actually",
+    "really",
+    "very",
+    "quite",
+    "perhaps",
+    "maybe",
+    "probably",
+];
+
+const FILLER_DENSITY_THRESHOLD: usize = 3;
+
+pub struct FillerHedge;
+
+impl Rule for FillerHedge {
+    fn id(&self) -> &'static str {
+        "slop-003"
+    }
+    fn name(&self) -> &'static str {
+        "Filler/Hedge Words"
+    }
+    fn description(&self) -> &'static str {
+        "Detects filler and hedge words that weaken comment clarity"
+    }
+    fn severity(&self) -> Severity {
+        Severity::Warn
+    }
+
+    fn check(
+        &self,
+        source: &[u8],
+        tree: &tree_sitter::Tree,
+        file_path: &Path,
+    ) -> Vec<Finding> {
+        let mut findings = Vec::new();
+        let source_str = match std::str::from_utf8(source) {
+            Ok(s) => s,
+            Err(_) => return findings,
+        };
+
+        let mut cursor = tree.walk();
+        Self::walk_tree(&mut cursor, source_str, file_path, &mut findings);
+        findings
+    }
+}
+
+impl FillerHedge {
+    fn walk_tree(
+        cursor: &mut tree_sitter::TreeCursor,
+        source: &str,
+        file_path: &Path,
+        findings: &mut Vec<Finding>,
+    ) {
+        loop {
+            let node = cursor.node();
+
+            if node.kind() == "comment"
+                && let Some(finding) = Self::check_comment(node, source, file_path)
+            {
+                findings.push(finding);
+            }
+
+            if cursor.goto_first_child() {
+                continue;
+            }
+            if cursor.goto_next_sibling() {
+                continue;
+            }
+            loop {
+                if !cursor.goto_parent() {
+                    return;
+                }
+                if cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+    }
+
+    fn check_comment(
+        node: tree_sitter::Node,
+        source: &str,
+        file_path: &Path,
+    ) -> Option<Finding> {
+        let text = node.utf8_text(source.as_bytes()).ok()?;
+
+        // Skip JSDoc blocks
+        if text.starts_with("/**") {
+            return None;
+        }
+
+        // Strip comment markers and check each line
+        let cleaned = text
+            .trim()
+            .strip_prefix("//")
+            .or_else(|| text.trim().strip_prefix("/*"))
+            .unwrap_or(text.trim());
+        let cleaned = cleaned.strip_suffix("*/").unwrap_or(cleaned);
+
+        for line in cleaned.lines() {
+            let line = line.trim().strip_prefix('*').unwrap_or(line.trim()).trim();
+            let lower = line.to_lowercase();
+
+            // Exempt "Note:" followed by a reference (RFC, URL, issue number)
+            if lower.starts_with("note:") {
+                let rest = line[5..].trim();
+                if Self::is_reference(rest) {
+                    continue;
+                }
+            }
+
+            // Check phrase-start patterns
+            for pattern in PHRASE_START_PATTERNS {
+                if lower.starts_with(pattern) {
+                    // Exempt single-word "just" mid-sentence where it carries meaning
+                    if *pattern == "just " && Self::is_meaningful_just(&lower) {
+                        continue;
+                    }
+
+                    let start = node.start_position();
+                    return Some(Finding {
+                        rule_id: "",
+                        message: "comment contains filler/hedge words".to_string(),
+                        severity: Severity::Warn,
+                        file: file_path.to_path_buf(),
+                        line: start.row + 1,
+                        column: start.column + 1,
+                        span: node.byte_range(),
+                        suggestion: Some(
+                            "Remove filler words — state the point directly.".to_string(),
+                        ),
+                    });
+                }
+            }
+
+            // Density heuristic: count filler words in this line
+            let word_count = lower
+                .split_whitespace()
+                .filter(|w| {
+                    let w = w.trim_matches(|c: char| c.is_ascii_punctuation());
+                    FILLER_WORDS.contains(&w)
+                })
+                .count();
+            if word_count >= FILLER_DENSITY_THRESHOLD {
+                let start = node.start_position();
+                return Some(Finding {
+                    rule_id: "",
+                    message: "comment contains filler/hedge words".to_string(),
+                    severity: Severity::Warn,
+                    file: file_path.to_path_buf(),
+                    line: start.row + 1,
+                    column: start.column + 1,
+                    span: node.byte_range(),
+                    suggestion: Some(
+                        "Remove filler words — state the point directly.".to_string(),
+                    ),
+                });
+            }
+        }
+
+        None
+    }
+
+    /// Check if the text after "Note:" is a reference (RFC, URL, issue number).
+    fn is_reference(text: &str) -> bool {
+        let lower = text.to_lowercase();
+        lower.starts_with("rfc")
+            || lower.starts_with("http")
+            || lower.starts_with('#')
+            || lower.starts_with("issue")
+            || lower.starts_with("see ")
+    }
+
+    /// Check if "just" is used meaningfully (e.g., "just-in-time", "just as").
+    fn is_meaningful_just(lower: &str) -> bool {
+        lower.starts_with("just-in-time") || lower.starts_with("just as ")
+    }
+}

--- a/src/rules/slop/mod.rs
+++ b/src/rules/slop/mod.rs
@@ -2,5 +2,8 @@
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
+pub mod commented_out_code;
+pub mod filler_hedge;
 pub mod reasoning_artifact;
 pub mod redundant_comment;
+pub mod self_narrating;

--- a/src/rules/slop/redundant_comment.rs
+++ b/src/rules/slop/redundant_comment.rs
@@ -28,6 +28,9 @@ impl Rule for RedundantComment {
     fn name(&self) -> &'static str {
         "Redundant Comment"
     }
+    fn description(&self) -> &'static str {
+        "Detects comments that merely restate the adjacent code without adding context"
+    }
     fn severity(&self) -> Severity {
         Severity::Warn
     }

--- a/tests/fixtures/slop/commented_out_code.js
+++ b/tests/fixtures/slop/commented_out_code.js
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 Steven Mosley <astrosteveo>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+// expect: slop-004
+// return result;
+function getValue() {
+    return null;
+}
+
+// expect: slop-004
+// const config = getConfig();
+// const user = fetchUser(config.userId);
+// if (user.isActive) {
+//     return user.profile;
+// }
+function loadProfile() {
+    return null;
+}
+
+// This should NOT trigger — normal prose comment
+// Users must wait for the async operation to complete
+async function fetchData(url) {
+    return await fetch(url);
+}
+
+// This should NOT trigger — JSDoc block
+/**
+ * const x = 10;
+ * return x + 1;
+ */
+function example() {
+    return 42;
+}
+
+// This should NOT trigger — expect annotation
+// expect: slop-001
+// Set the user name
+user.setUserName(name);
+
+// This should NOT trigger — explains why, not code
+// Early return for null safety — downstream expects a value
+function safeGet(obj, key) {
+    if (!obj) return null;
+    return obj[key];
+}

--- a/tests/fixtures/slop/filler_hedge.js
+++ b/tests/fixtures/slop/filler_hedge.js
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Steven Mosley <astrosteveo>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+// expect: slop-003
+// Basically, this sets the user's name
+user.setName(name);
+
+// expect: slop-003
+// Simply put this handles the validation logic
+function validate(input) {
+    return input != null;
+}
+
+// expect: slop-003
+// Obviously, we return the cached value here
+function getCached(key) {
+    return cache.get(key);
+}
+
+// expect: slop-003
+// It's worth noting that this resets the counter
+let counter = 0;
+
+// expect: slop-003
+// Please note the timeout is set to 30 seconds
+const timeout = 30000;
+
+// expect: slop-003
+// Essentially, we just basically filter the invalid items
+function filterItems(items) {
+    return items.filter(Boolean);
+}
+
+// This should NOT trigger — "Note:" followed by a reference
+// Note: see RFC 7231 for details on status codes
+function handleStatus(code) {
+    return code >= 200 && code < 300;
+}
+
+// This should NOT trigger — normal explanatory comment
+// Retry with exponential backoff to avoid thundering herd
+async function fetchWithRetry(url) {
+    return await fetch(url);
+}
+
+// This should NOT trigger — JSDoc block
+/**
+ * Just a simple helper for formatting dates
+ */
+function formatDate(date) {
+    return date.toISOString();
+}
+
+// This should NOT trigger — explains a real constraint
+// The buffer must be exactly 1024 bytes for the hardware interface
+const BUFFER_SIZE = 1024;

--- a/tests/fixtures/slop/self_narrating.js
+++ b/tests/fixtures/slop/self_narrating.js
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Steven Mosley <astrosteveo>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+// expect: slop-005
+// Here we initialize the configuration
+const config = {};
+
+// expect: slop-005
+// We need to validate the input before processing
+function validate(input) {
+    return input != null;
+}
+
+// expect: slop-005
+// This function handles the data transformation
+function transform(data) {
+    return data.map(String);
+}
+
+// expect: slop-005
+// This handles the error case for invalid inputs
+function handleError(err) {
+    console.error(err);
+}
+
+// expect: slop-005
+// The following code sets up the database connection
+const db = null;
+
+// This should NOT trigger — explains WHY not WHAT
+// Normalize Unicode before comparison to handle locale-specific equivalence
+user.setName(normalizeName(name));
+
+// This should NOT trigger — JSDoc
+/**
+ * This function formats dates for display
+ */
+function formatDate(date) {
+    return date.toISOString();
+}
+
+// This should NOT trigger — TODO directive
+// TODO: we should refactor this later
+function legacyCode() {
+    return true;
+}

--- a/tests/integration/scan_test.rs
+++ b/tests/integration/scan_test.rs
@@ -117,6 +117,40 @@ fn check_expect_annotations(fixture_path: &str) {
     );
 }
 
+fn check_expect_annotations_for_rule(fixture_path: &str, rule_id: &str) {
+    let source = std::fs::read_to_string(fixture_path).expect("fixture should exist");
+
+    let expect_tag = format!("// expect: {rule_id}");
+    let mut expected_lines: Vec<usize> = Vec::new();
+    for (i, line) in source.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.starts_with(&expect_tag) {
+            expected_lines.push(i + 2);
+        }
+    }
+
+    let output = patina_bin()
+        .args(["scan", fixture_path, "--format", "json"])
+        .output()
+        .expect("failed to run patina");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let findings: Vec<serde_json::Value> = serde_json::from_str(&stdout)
+        .expect("output should be valid JSON");
+
+    // Filter to only findings for the specified rule
+    let actual_lines: Vec<usize> = findings
+        .iter()
+        .filter(|f| f["rule_id"].as_str() == Some(rule_id))
+        .map(|f| f["line"].as_u64().unwrap() as usize)
+        .collect();
+
+    assert_eq!(
+        actual_lines, expected_lines,
+        "{fixture_path} ({rule_id}): findings should match // expect: annotations\nExpected: {expected_lines:?}\nActual: {actual_lines:?}"
+    );
+}
+
 #[test]
 fn expect_annotations_match_findings_redundant_comments() {
     check_expect_annotations("tests/fixtures/slop/redundant_comments.js");
@@ -125,6 +159,21 @@ fn expect_annotations_match_findings_redundant_comments() {
 #[test]
 fn expect_annotations_match_findings_reasoning_artifacts() {
     check_expect_annotations("tests/fixtures/slop/reasoning_artifacts.js");
+}
+
+#[test]
+fn expect_annotations_match_findings_filler_hedge() {
+    check_expect_annotations_for_rule("tests/fixtures/slop/filler_hedge.js", "slop-003");
+}
+
+#[test]
+fn expect_annotations_match_findings_commented_out_code() {
+    check_expect_annotations_for_rule("tests/fixtures/slop/commented_out_code.js", "slop-004");
+}
+
+#[test]
+fn expect_annotations_match_findings_self_narrating() {
+    check_expect_annotations_for_rule("tests/fixtures/slop/self_narrating.js", "slop-005");
 }
 
 #[test]
@@ -149,4 +198,103 @@ fn scanning_directory_finds_all_js_files() {
             "finding should be from a .js file: {file}"
         );
     }
+}
+
+#[test]
+fn rules_subcommand_terminal_output() {
+    let output = patina_bin()
+        .args(["rules"])
+        .output()
+        .expect("failed to run patina");
+
+    assert!(output.status.success(), "rules subcommand should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("slop-001"), "should list slop-001");
+    assert!(stdout.contains("slop-002"), "should list slop-002");
+    assert!(stdout.contains("slop-003"), "should list slop-003");
+    assert!(stdout.contains("slop-004"), "should list slop-004");
+    assert!(stdout.contains("slop-005"), "should list slop-005");
+    assert!(stdout.contains("Redundant Comment"), "should show rule names");
+}
+
+#[test]
+fn rules_subcommand_json_output() {
+    let output = patina_bin()
+        .args(["rules", "--format", "json"])
+        .output()
+        .expect("failed to run patina");
+
+    assert!(output.status.success(), "rules --format json should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let rules: Vec<serde_json::Value> = serde_json::from_str(&stdout)
+        .expect("JSON output should be parseable");
+
+    assert_eq!(rules.len(), 5, "should have 5 rules");
+
+    // Check first rule structure
+    let first = &rules[0];
+    assert!(first["id"].is_string());
+    assert!(first["name"].is_string());
+    assert!(first["severity"].is_string());
+    assert!(first["description"].is_string());
+
+    // Verify all rule IDs are present
+    let ids: Vec<&str> = rules.iter().map(|r| r["id"].as_str().unwrap()).collect();
+    assert_eq!(ids, vec!["slop-001", "slop-002", "slop-003", "slop-004", "slop-005"]);
+}
+
+#[test]
+fn severity_threshold_filters_findings() {
+    // All current rules are "warn" severity, so --severity-threshold=error should filter them out
+    let output = patina_bin()
+        .args([
+            "scan",
+            "tests/fixtures/slop/",
+            "--format",
+            "json",
+            "--severity-threshold",
+            "error",
+        ])
+        .output()
+        .expect("failed to run patina");
+
+    assert!(
+        output.status.success(),
+        "should exit 0 when all findings filtered out"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let findings: Vec<serde_json::Value> = serde_json::from_str(&stdout)
+        .expect("output should be valid JSON");
+    assert!(
+        findings.is_empty(),
+        "error threshold should filter all warn-level findings"
+    );
+}
+
+#[test]
+fn severity_threshold_warn_keeps_warnings() {
+    let output = patina_bin()
+        .args([
+            "scan",
+            "tests/fixtures/slop/redundant_comments.js",
+            "--format",
+            "json",
+            "--severity-threshold",
+            "warn",
+        ])
+        .output()
+        .expect("failed to run patina");
+
+    assert!(
+        !output.status.success(),
+        "should exit non-zero when warn findings pass threshold"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let findings: Vec<serde_json::Value> = serde_json::from_str(&stdout)
+        .expect("output should be valid JSON");
+    assert_eq!(findings.len(), 6, "warn threshold should keep all warn findings");
 }


### PR DESCRIPTION
## Summary

- **slop-003 (Filler/Hedge Words)**: Detects filler phrases (`Basically,`, `Simply put`, `Obviously,`) and hedge language in comments, with a density heuristic that flags comments with 3+ filler words
- **slop-004 (Commented-Out Code)**: Detects single-line commented-out statements (`// return result;`) and multi-line groups where ≥60% of lines match code patterns (keywords, assignments, method calls)
- **slop-005 (Self-Narrating Comments)**: Detects first-person narration (`Here we`, `We need to`, `This function`) that describes code instead of explaining why
- **`patina rules` subcommand** (#26): Lists all registered rules with ID, name, severity, and description in terminal table or JSON format
- **`--severity-threshold` flag** (#27 partial): Filters scan findings by minimum severity level (`error`, `warn`, `info`); config-file overrides deferred to v0.3/#28
- **`description()` on Rule trait**: Added to support the rule catalog

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `cargo test` — all 24 tests pass (9 unit + 15 integration)
- [x] `cargo clippy` — no warnings
- [x] `// expect:` annotation tests for all 3 new rule fixtures
- [x] `rules` subcommand tests (terminal + JSON output, verifies all 5 rule IDs)
- [x] `--severity-threshold error` filters all warn-level findings to empty
- [x] `--severity-threshold warn` preserves warn-level findings
- [x] Clean fixture produces no findings from new rules

Closes #23, #24, #25, #26. Partially addresses #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)